### PR TITLE
Smart Expenses

### DIFF
--- a/BROKE/BROKE.cs
+++ b/BROKE/BROKE.cs
@@ -38,6 +38,11 @@ namespace BROKE
             return InvoiceItems.Sum(item => item.Expenses);
         }
 
+        public double PendingRevenue()
+        {
+            return InvoiceItems.Sum(item => item.Revenue);
+        }
+
         private int WindowWidth = 360, WindowHeight = 540;
         private bool DrawSettings = false;
 
@@ -108,9 +113,6 @@ namespace BROKE
 
         public void ProcessExpenseReport()
         {
-            var totalRevenue = InvoiceItems.Sum(item => item.Revenue);
-            CashInRevenues();
-            PayExpenses(totalRevenue);
            // DisplayExpenseReport();
             button.SetTrue();
         }
@@ -246,11 +248,7 @@ namespace BROKE
             GUILayout.Label("Net Revenue: ", yellowText);
             GUILayout.Label("√" + Math.Abs(totalRevenue - totalExpenses).ToString("N"), (totalRevenue - totalExpenses) < 0 ? redText : greenText);
             GUILayout.EndHorizontal();
-
-            GUILayout.BeginHorizontal();
-            GUILayout.Label("Remaining Debt: ", yellowText);
-            GUILayout.Label("√"+RemainingDebt().ToString("N"), RemainingDebt() != 0 ? redText : greenText);
-            GUILayout.EndHorizontal();
+            
             GUILayout.BeginHorizontal();
             if (GUILayout.Button(((Texture)GameDatabase.Instance.GetTexture("BROKE/Textures/gear", false)), GUILayout.ExpandWidth(false)))
             {
@@ -263,8 +261,13 @@ namespace BROKE
                 if (!double.TryParse(payAmountTxt, out toPay))
                 {
                     toPay = -1;
-                    payAmountTxt = "-1";
+                    payAmountTxt = "Pay Maximum";
                 }
+                else
+                {
+                    toPay += PendingRevenue();
+                }
+                CashInRevenues();
                 toPay = Math.Min(toPay, RemainingDebt());
                 PayExpenses(toPay);
             }
@@ -453,6 +456,7 @@ namespace BROKE
 
         public double PayExpenses(double MaxToPay = -1)
         {
+            LogFormatted_DebugOnly("Paying Expenses!");
             if (HighLogic.CurrentGame.Mode != Game.Modes.CAREER) //No funds outside of career
                 return 0;
 

--- a/BROKE/BROKE.csproj
+++ b/BROKE/BROKE.csproj
@@ -21,6 +21,8 @@
     <DefineConstants>DEBUG;TRACE</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
+    <LangVersion>
+    </LangVersion>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <DebugType>pdbonly</DebugType>
@@ -48,6 +50,7 @@
     <Compile Include="BROKE.cs" />
     <Compile Include="BROKE_Data.cs" />
     <Compile Include="IFundingModifier.cs" />
+    <Compile Include="InvoiceItem.cs" />
     <Compile Include="KSPPluginFramework\ConfigNodeStorage.cs" />
     <Compile Include="KSPPluginFramework\ExtensionsUnity.cs" />
     <Compile Include="KSPPluginFramework\MonoBehaviourExtended.cs" />

--- a/BROKE/BROKE_Data.cs
+++ b/BROKE/BROKE_Data.cs
@@ -39,25 +39,16 @@ namespace BROKE
 
             try
             {
-                print("Loading BROKE data");
                 ConfigNode BROKENode = node.GetNode("BROKE_Data");
                 if (BROKENode != null)
                 {
-                    print("Loading invoices");
-                    ConfigNode invoices = BROKENode.GetNode("Invoices");
-                    if (invoices != null)
-                    {
-                        print("invoices is not null");
-                        BROKE.Instance.InvoiceItems.Clear();
-                        BROKE.Instance.InvoiceItems.AddRange(ConfigNodeToList<InvoiceItem>(invoices)); 
-                    }
                     int skinID = 2;
                     int.TryParse(BROKENode.GetValue("Skin"), out skinID);
                     BROKE.Instance.SelectSkin(skinID);
                     ConfigNode disabled = BROKENode.GetNode("DisabledFMs");
                     if (disabled != null)
                         BROKE.Instance.disabledFundingModifiers = ConfigNodeToList(disabled);
-
+                    print("loaded disabled list");
                     //load each IFundingModifier
                     foreach (IFundingModifier fundingMod in BROKE.Instance.fundingModifiers)
                     {
@@ -65,11 +56,18 @@ namespace BROKE
                         if (fmNode != null)
                             fundingMod.LoadData(fmNode);
                     }
+                    print("loaded funding modifiers");
+                    ConfigNode invoices = BROKENode.GetNode("Invoices");
+                    if (invoices != null)
+                    {
+                        BROKE.Instance.InvoiceItems.Clear();
+                        BROKE.Instance.InvoiceItems.AddRange(ConfigNodeToList<InvoiceItem>(invoices));
+                    }
                 }
             }
             catch (Exception e)
             {
-                UnityEngine.Debug.Log("Exception while loading BROKE data! "+ e.Message);
+                UnityEngine.Debug.LogException(e);
             }
         }
 
@@ -105,8 +103,6 @@ namespace BROKE
             {
                 T value = new T();
                 ConfigNode.LoadObjectFromConfig(value, element);
-                print("Loading element :" + element.name);
-                //retList.Add(ConfigNode.CreateObjectFromConfig<T>(element));
                 retList.Add(value);
             }
             return retList;

--- a/BROKE/IFundingModifier.cs
+++ b/BROKE/IFundingModifier.cs
@@ -32,16 +32,16 @@ namespace BROKE
         /// <summary>
         /// Return the funds gained and lost for this Quarter. The returned values will be added/removed by B.R.O.K.E. so there is no need to do that yourself.
         /// </summary>
-        /// <returns>double[2] income, expenses</returns>
-        double[] ProcessQuarterly();
+        /// <returns>An InvoiceItem representing the quarterly invoice.</returns>
+        InvoiceItem ProcessQuarterly();
 
         /// <summary>
         /// Return the funds gained and lost Yearly. The returned values will be added/removed by B.R.O.K.E. so there is no need to do that yourself.
         /// Note that this should NOT be the sum of the Quarterly income/expenses for the year. That's calculated by B.R.O.K.E. This is just for
         /// income/expenses that happen ONLY once a year
         /// </summary>
-        /// <returns>double[2] income, expenses</returns>
-        double[] ProcessYearly();
+        /// <returns>An InvoiceItem representing the yearly invoice.</returns>
+        InvoiceItem ProcessYearly();
 
         /// <summary>
         /// This will be called once a day and should be used to update any time-based funding information (ie, # of running missions that day, which Kerbals are at KSC and for how long, etc)

--- a/BROKE/IFundingModifier.cs
+++ b/BROKE/IFundingModifier.cs
@@ -83,5 +83,19 @@ namespace BROKE
         /// Draws the main GUI, an extension of the Expense Report
         /// </summary>
         void DrawMainGUI();
+
+        /// <summary>
+        /// Called when some payment is put toward expenses on an invoice item generated from this funding modifier.
+        /// </summary>
+        /// <param name="sender">The invoice item.</param>
+        /// <param name="args">Data about the payment.</param>
+        void OnInvoicePaid(object sender, InvoiceItem.InvoicePaidEventArgs args);
+
+        /// <summary>
+        /// Called when an invoice is unpaid during a period.
+        /// </summary>
+        /// <param name="sender">The invoice item.</param>
+        /// <param name="args">Empty event arguments, can be ignored.</param>
+        void OnInvoiceUnpaid(object sender, EventArgs args);
     }
 }

--- a/BROKE/InvoiceItem.cs
+++ b/BROKE/InvoiceItem.cs
@@ -5,7 +5,7 @@ using System.Text;
 
 namespace BROKE
 {
-    public sealed class InvoiceItem
+    public sealed class InvoiceItem : IPersistenceLoad
     {
         /// <summary>
         /// Only for (de-)serialization purposes.  DO NOT USE.
@@ -25,6 +25,7 @@ namespace BROKE
             Revenue = revenue;
             Expenses = expenses;
             InvoiceReason = reason;
+            PersistenceLoad();
         }
         
         [Persistent]
@@ -100,6 +101,16 @@ namespace BROKE
             var handler = InvoiceUnpaid;
             if (handler != null)
                 handler(this, EventArgs.Empty);
+        }
+
+        public void PersistenceLoad()
+        {
+            var relatedFundingModifier = BROKE.Instance.fundingModifiers.FirstOrDefault(modifier => modifier.GetName() == InvoiceName);
+            if (relatedFundingModifier != null)
+            {
+                InvoicePaid += relatedFundingModifier.OnInvoicePaid;
+                InvoiceUnpaid += relatedFundingModifier.OnInvoiceUnpaid; 
+            }
         }
 
         public static readonly InvoiceItem EmptyInvoice = new InvoiceItem("", 0, 0);

--- a/BROKE/InvoiceItem.cs
+++ b/BROKE/InvoiceItem.cs
@@ -1,0 +1,107 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+
+namespace BROKE
+{
+    public sealed class InvoiceItem
+    {
+        /// <summary>
+        /// Only for (de-)serialization purposes.  DO NOT USE.
+        /// </summary>
+        public InvoiceItem()
+        { }
+        /// <summary>
+        /// Constructor for creating an InvoiceItem.
+        /// </summary>
+        /// <param name="name">Must equal the name of your funding modifier.</param>
+        /// <param name="revenue">The revenue tied to this invoice.</param>
+        /// <param name="expenses">The expenses tied to this invoice.</param>
+        /// <param name="reason">(Optional parameter) The category for the invoice.</param>
+        public InvoiceItem(string name, double revenue, double expenses, TransactionReasons reason = TransactionReasons.None)
+        {
+            InvoiceName = name;
+            Revenue = revenue;
+            Expenses = expenses;
+            InvoiceReason = reason;
+        }
+        
+        [Persistent]
+        private string invoiceName;
+
+        public string InvoiceName
+        {
+            get { return invoiceName; }
+            private set { invoiceName = value; }
+        }
+
+        [Persistent]
+        private double revenue;
+
+        public double Revenue
+        {
+            get { return revenue; }
+            private set { revenue = value; }
+        }
+
+        [Persistent]
+        private double expenses;
+
+        public double Expenses
+        {
+            get { return expenses; }
+            private set { expenses = value; }
+        }
+
+        [Persistent]
+        private TransactionReasons reason;
+
+        public TransactionReasons InvoiceReason
+        {
+            get { return reason; }
+            private set { reason = value; }
+        }
+
+
+        public class InvoicePaidEventArgs : EventArgs
+        {
+            public InvoicePaidEventArgs(double expenses, double amountPaid)
+            {
+                AmountPaid = amountPaid;
+                PaidInFull = AmountPaid >= expenses;
+            }
+            public double AmountPaid { get; private set; }
+            public bool PaidInFull { get; private set; }
+        }
+
+        public event EventHandler<InvoicePaidEventArgs> InvoicePaid;
+
+        internal void WithdrawRevenue()
+        {
+            Revenue = 0;
+        }
+
+        internal void PayInvoice(double amountPaid)
+        {
+            var handler = InvoicePaid;
+            if (handler != null)
+            {
+                var args = new InvoicePaidEventArgs(Expenses, amountPaid);
+                handler(this, args);
+            }
+            Expenses -= amountPaid;
+        }
+
+        public event EventHandler<EventArgs> InvoiceUnpaid;
+
+        internal void NotifyMissedPayment()
+        {
+            var handler = InvoiceUnpaid;
+            if (handler != null)
+                handler(this, EventArgs.Empty);
+        }
+
+        public static readonly InvoiceItem EmptyInvoice = new InvoiceItem("", 0, 0);
+    }
+}

--- a/BROKEExampleFundingModifier/ExampleFM.cs
+++ b/BROKEExampleFundingModifier/ExampleFM.cs
@@ -49,7 +49,7 @@ namespace BROKEExampleFundingModifier
             Debug.Log("Example Quarterly update!");
             AllTimeRevenue += 31;
             AllTimeExpenses += 42;
-            var invoice = new InvoiceItem(GetName(), 31, 42);
+            var invoice = new InvoiceItem(this, 31, 42);
             return invoice;
         }
 
@@ -58,7 +58,7 @@ namespace BROKEExampleFundingModifier
             Debug.Log("Example Yearly update!");
             AllTimeRevenue += 100;
             AllTimeExpenses += 25;
-            var invoice = new InvoiceItem(GetName(), 100, 25);
+            var invoice = new InvoiceItem(this, 100, 25);
             return invoice;
         }
 

--- a/BROKEExampleFundingModifier/ExampleFM.cs
+++ b/BROKEExampleFundingModifier/ExampleFM.cs
@@ -31,7 +31,7 @@ namespace BROKEExampleFundingModifier
             Debug.Log("Example Disabled!");
         }
 
-        private void OnInvoicePaid(object sender, InvoiceItem.InvoicePaidEventArgs args)
+        public void OnInvoicePaid(object sender, InvoiceItem.InvoicePaidEventArgs args)
         {
             if (args.PaidInFull)
                 Debug.Log("Invoice Paid in full");
@@ -39,7 +39,7 @@ namespace BROKEExampleFundingModifier
                 Debug.Log("Invoice Paid : " + args.AmountPaid);
         }
 
-        private void OnUnpaidInvoice(object sender, EventArgs args)
+        public void OnInvoiceUnpaid(object sender, EventArgs args)
         {
             Debug.Log("Invoice Unpaid!");
         }
@@ -50,8 +50,6 @@ namespace BROKEExampleFundingModifier
             AllTimeRevenue += 31;
             AllTimeExpenses += 42;
             var invoice = new InvoiceItem(GetName(), 31, 42);
-            invoice.InvoicePaid += OnInvoicePaid;
-            invoice.InvoiceUnpaid += OnUnpaidInvoice;
             return invoice;
         }
 
@@ -61,8 +59,6 @@ namespace BROKEExampleFundingModifier
             AllTimeRevenue += 100;
             AllTimeExpenses += 25;
             var invoice = new InvoiceItem(GetName(), 100, 25);
-            invoice.InvoicePaid += OnInvoicePaid;
-            invoice.InvoiceUnpaid += OnUnpaidInvoice;
             return invoice;
         }
 

--- a/BROKEExampleFundingModifier/ExampleFM.cs
+++ b/BROKEExampleFundingModifier/ExampleFM.cs
@@ -31,20 +31,39 @@ namespace BROKEExampleFundingModifier
             Debug.Log("Example Disabled!");
         }
 
-        public double[] ProcessYearly()
+        private void OnInvoicePaid(object sender, InvoiceItem.InvoicePaidEventArgs args)
         {
-            Debug.Log("Example Yearly update!");
-            AllTimeRevenue += 100;
-            AllTimeExpenses += 25;
-            return new double[] { 100, 25 };
+            if (args.PaidInFull)
+                Debug.Log("Invoice Paid in full");
+            else
+                Debug.Log("Invoice Paid : " + args.AmountPaid);
         }
 
-        public double[] ProcessQuarterly()
+        private void OnUnpaidInvoice(object sender, EventArgs args)
+        {
+            Debug.Log("Invoice Unpaid!");
+        }
+
+        public InvoiceItem ProcessQuarterly()
         {
             Debug.Log("Example Quarterly update!");
             AllTimeRevenue += 31;
             AllTimeExpenses += 42;
-            return new double[] { 31, 42 };
+            var invoice = new InvoiceItem(GetName(), 31, 42);
+            invoice.InvoicePaid += OnInvoicePaid;
+            invoice.InvoiceUnpaid += OnUnpaidInvoice;
+            return invoice;
+        }
+
+        public InvoiceItem ProcessYearly()
+        {
+            Debug.Log("Example Yearly update!");
+            AllTimeRevenue += 100;
+            AllTimeExpenses += 25;
+            var invoice = new InvoiceItem(GetName(), 100, 25);
+            invoice.InvoicePaid += OnInvoicePaid;
+            invoice.InvoiceUnpaid += OnUnpaidInvoice;
+            return invoice;
         }
 
         public void DailyUpdate() { Debug.Log("Example Daily update!"); }
@@ -75,5 +94,6 @@ namespace BROKEExampleFundingModifier
 
         public void DrawSettingsGUI() { GUILayout.Label("Example settings!"); }
         public void DrawMainGUI() { GUILayout.Label("Hello, World!"); }
+
     }
 }


### PR DESCRIPTION
I was taking a look at adding loans as funding modifiers and I noticed that there was no way to notify that debt had been paid. Additionally, it was really easy to use BROKE to get excess income but never pay expenses. This PR removes the double[] passing and replaces it with "smart objects" as InvoiceItems. This fixes the above issues and adds more extensibility for IFundingModifiers.
